### PR TITLE
Accessibility: Don't nix the outline of a focused button

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -60,7 +60,6 @@ function getColor(props) {
 }
 
 const ButtonWrapper = styled.button`
-  outline: none;
   font-size: 16px;
   padding: 8px 16px;
   font-weight: normal;


### PR DESCRIPTION
Unfortunately the `withRipple` HOC still hides the outline due to `overflow: hidden;`, but at least there's a small amount visible like this.