### PR TITLE
Consistent button border size

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -65,7 +65,7 @@ const ButtonWrapper = styled.button`
   padding: 8px 16px;
   font-weight: normal;
   border-style: solid;
-  border-width: ${props => props.outline && !props.clear ? '1px' : '0px'};
+  border-width: ${props => !props.clear ? '1px' : '0px'};
   border-radius: 4px;
   border-color: ${props => getColor(props)};
   color: ${props => props.outline || props.clear ? getColor(props) : '#fff'};
@@ -96,6 +96,7 @@ const ButtonWrapper = styled.button`
     background: ${props => getHoverColor(props)};
     ${props => !props.clear && 'color: #fff;'}
     ${props => !props.disabled && 'cursor: pointer;'}
+    ${props => !props.outline && !props.clear ? `border-color: ${getHoverColor(props)};` : ''};
   }
 
   &:active {


### PR DESCRIPTION
Adjacent buttons with/without the outline prop will now have the same height.

Old:
![different-height](https://user-images.githubusercontent.com/612020/32628892-71540130-c5eb-11e7-9ed2-ba8b74d17179.png)

New:
![same-height](https://user-images.githubusercontent.com/612020/32628899-753c980c-c5eb-11e7-8425-63a0d8972805.png)

New with hover:
![same-height-hovered](https://user-images.githubusercontent.com/612020/32628905-79582028-c5eb-11e7-9c3f-8e9f72083b9c.png)
