### PR TITLE
Only pass required props to inner button container

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -124,11 +124,11 @@ const rippleStyles = {
 };
 
 const Button = ({ children, ...rest }) => {
-  const { disabled, small, large } = rest;
+  const { disabled, small, large, className } = rest;
   return (
     <ButtonWrapper {...rest}
     >
-      <ButtonContent disabled={disabled} small={small} large={large} wrapperStyles={rippleStyles}>
+      <ButtonContent {...{ disabled, small, large, className }} wrapperStyles={rippleStyles}>
         {children}
       </ButtonContent>
     </ButtonWrapper>

--- a/src/Button.js
+++ b/src/Button.js
@@ -123,14 +123,17 @@ const rippleStyles = {
   display: 'block',
 };
 
-const Button = ({ children, ...rest }) => (
-  <ButtonWrapper {...rest}
-  >
-    <ButtonContent {...rest} wrapperStyles={rippleStyles}>
-      {children}
-    </ButtonContent>
-  </ButtonWrapper>
-);
+const Button = ({ children, ...rest }) => {
+  const { disabled, small, large } = rest;
+  return (
+    <ButtonWrapper {...rest}
+    >
+      <ButtonContent disabled={disabled} small={small} large={large} wrapperStyles={rippleStyles}>
+        {children}
+      </ButtonContent>
+    </ButtonWrapper>
+  );
+}
 
 Button.propTypes = {
   children: PropTypes.any,


### PR DESCRIPTION
Avoids passing through event handlers, and therefore removes double event firing.