### PR TITLE
Ensure <button> children are semantically correct

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -102,7 +102,7 @@ const ButtonWrapper = styled.button`
   }
 `;
 
-const ButtonContent = withRipple(styled.div`
+const ButtonContent = withRipple(styled.span`
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
`<div>` shouldn't live inside a `<button>`